### PR TITLE
Multi-window mode support

### DIFF
--- a/barricade/src/main/java/com/mutualmobile/barricade/Barricade.java
+++ b/barricade/src/main/java/com/mutualmobile/barricade/Barricade.java
@@ -3,6 +3,7 @@ package com.mutualmobile.barricade;
 import android.app.Application;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import com.mutualmobile.barricade.activity.BarricadeActivity;
 import com.mutualmobile.barricade.response.BarricadeResponse;
 import com.mutualmobile.barricade.response.BarricadeResponseSet;
@@ -49,8 +50,7 @@ public class Barricade {
   private Barricade() {
   }
 
-  private Barricade(AssetFileManager fileManager, IBarricadeConfig barricadeConfig, long delay,
-      Application application) {
+  private Barricade(AssetFileManager fileManager, IBarricadeConfig barricadeConfig, long delay, Application application) {
     this.barricadeConfig = barricadeConfig;
     this.fileManager = fileManager;
     this.delay = delay;
@@ -124,8 +124,7 @@ public class Barricade {
     return new okhttp3.Response.Builder().code(barricadeResponse.statusCode)
         .request(chain.request())
         .protocol(Protocol.HTTP_1_0)
-        .body(ResponseBody.create(MediaType.parse(barricadeResponse.contentType),
-            fileResponse.getBytes()))
+        .body(ResponseBody.create(MediaType.parse(barricadeResponse.contentType), fileResponse.getBytes()))
         .addHeader("content-type", barricadeResponse.contentType)
         .build();
   }
@@ -140,8 +139,7 @@ public class Barricade {
 
   private String getResponseFromFile(String endpoint, String variant) {
     // TODO: 4/4/17 Check with other file formats other than JSON
-    String fileName =
-        ROOT_DIRECTORY + File.separator + endpoint + File.separator + variant + ".json";
+    String fileName = ROOT_DIRECTORY + File.separator + endpoint + File.separator + variant + ".json";
     return fileManager.getContentsOfFileAsString(fileName);
   }
 
@@ -202,7 +200,11 @@ public class Barricade {
    */
   public void launchConfigActivity(Context context) {
     Intent intent = new Intent(context, BarricadeActivity.class);
-    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+      intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_LAUNCH_ADJACENT);
+    } else {
+      intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+    }
     context.startActivity(intent);
   }
 }


### PR DESCRIPTION
Barricade config UI now opens in adjacent window when consumer app is in multi-window mode. If the app is not in multi-window mode or running on version older than N, it opens in the same window as before.